### PR TITLE
Improvement: When init checks for a default redis instance

### DIFF
--- a/lib/memurai_db.js
+++ b/lib/memurai_db.js
@@ -8,9 +8,14 @@ let storedDb;
 async function getDB() {
   if (storedDb)
     return storedDb;
-  const port = await getPort();
-  child_process.spawn(process.platform === 'win32' ? 'memurai' : 'redis', ['--port', port, '--save', '""', "--appendonly", "no"], {stdio:'ignore'})
-  storedDb = new Redis({port})
+  const port = getPort();
+  // Checks if a Redis default instance is running
+  storedDb = new Redis()
+  storedDb.on('error', err => {
+    // If not invokes an instance of Redis
+    child_process.spawn(process.platform === 'win32' ? 'memurai' : 'redis', ['--port', port, '--save', '""', "--appendonly", "no"], {stdio:'ignore'})
+    storedDb = new Redis({port})
+  })
   return storedDb;
 }
 


### PR DESCRIPTION
The current App doen't check if a running instance of Redis is running if there is one , then uses it. 